### PR TITLE
Fix Typo in Backend Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Also, check out the AI Video Boilerplate for Chrome Extensions: [https://github.
 
 ## Features
 
--  **Backend**: Simple Flask sever, just serves files.
+-  **Backend**: Simple Flask server, just serves files.
 
 -  **Live Video**: From your webcam, desktop, browser tab, or a local .mp4 or .mov file
 


### PR DESCRIPTION
Fix typo in README: Change "sever" to "server" in the Backend section